### PR TITLE
Fix: typo error for injecting values for hem-tls secret from vallues.yaml

### DIFF
--- a/charts/templates/hem-tls.yaml
+++ b/charts/templates/hem-tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  tls.crt: {{ .Values.TLS_CRT }}
-  tls.key: {{ .Values.TLS_KEY }}
+  tls.crt: {{ .Values.secret.TLS_CRT }}
+  tls.key: {{ .Values.secret.TLS_KEY }}
 kind: Secret
 metadata:
   name: zerone-tls-cert

--- a/charts/templates/secret.yaml
+++ b/charts/templates/secret.yaml
@@ -20,30 +20,8 @@ items:
     tls.key: {{ .Values.secret.TLS_KEY }}
   kind: Secret
   metadata:
-    annotations:
-      cert-manager.io/alt-names: '*.staging.01cloud.dev,staging.01cloud.dev'
-      cert-manager.io/certificate-name: zerone-cloud-staging-crt
-      cert-manager.io/common-name: staging.01cloud.dev
-      cert-manager.io/ip-sans: ""
-      cert-manager.io/issuer-group: ""
-      cert-manager.io/issuer-kind: ClusterIssuer
-      cert-manager.io/issuer-name: letsencrypt-issuer
-      cert-manager.io/uri-sans: ""
     name: zerone-tls-cert
   type: kubernetes.io/tls
-
-  # metadata:
-  #   annotations:
-  #     cert-manager.io/alt-names: '*.staging.01cloud.dev,staging.01cloud.dev'
-  #     cert-manager.io/certificate-name: zerone-cloud-staging-crt
-  #     cert-manager.io/common-name: staging.01cloud.dev
-  #     cert-manager.io/ip-sans: ""
-  #     cert-manager.io/issuer-group: ""
-  #     cert-manager.io/issuer-kind: ClusterIssuer
-  #     cert-manager.io/issuer-name: letsencrypt-issuer
-  #     cert-manager.io/uri-sans: ""
-  #   name: zerone-tls-cert
-  # type: kubernetes.io/tls
 kind: List
 metadata:
   resourceVersion: ""


### PR DESCRIPTION
- typo in hem-tls.yaml was fixed necessary for creating secret by parsing the value from values.yaml during deployment.